### PR TITLE
Writing exported files in UTF-8 encoding

### DIFF
--- a/operators/export_lrc.py
+++ b/operators/export_lrc.py
@@ -1,4 +1,5 @@
 import bpy
+import codecs
 from bpy_extras.io_utils import ExportHelper
 
 from .pylrc.lyrics import Lyrics
@@ -11,27 +12,27 @@ class ExportLRC(bpy.types.Operator, ExportHelper):
     bl_label = 'Export LRC'
     bl_idname = 'sequencerextra.export_lrc'
     bl_description = 'Export subtitles as LRC\n\nThis format is usually used for music.'
-    
+
     filename_ext = ".lrc"
-    
+
     @classmethod
     def poll(self, context):
         scene = context.scene
         try:
             text_strips = get_text_strips(scene)
-        
+
             if len(text_strips) > 0:
                 return True
             else:
                 return False
         except AttributeError:
             return False
-    
+
     def execute(self, context):
         scene = context.scene
         fps = scene.render.fps/scene.render.fps_base
         text_strips = get_text_strips(scene)
-        
+
         lyric_list = []
         for i in range(len(text_strips)):
             strip = text_strips[i]
@@ -39,7 +40,7 @@ class ExportLRC(bpy.types.Operator, ExportHelper):
                 message = ".lrc files cannot store subtitles longer than 59:59.99"
                 self.report(set({'ERROR'}), message)
                 return {"FINISHED"}
-            
+
             start = seconds_to_timecode(strip.frame_final_start / fps)
 
             text_lines = strip.text.split('\n')
@@ -47,20 +48,20 @@ class ExportLRC(bpy.types.Operator, ExportHelper):
             for line in text_lines:
                 text += line.strip() + ' '
             text = text.rstrip()
-            
+
             lyric_list.append(LyricLine(start, text))
-            
+
             if i < len(text_strips) - 1:
                 if text_strips[i + 1].frame_start > strip.frame_final_end:
                     start = seconds_to_timecode(strip.frame_final_end / fps)
                     lyric_list.append(LyricLine(start, ""))
-            
+
             elif i == len(text_strips) - 1:
                 start = seconds_to_timecode(strip.frame_final_end / fps)
                 lyric_list.append(LyricLine(start, ""))
-        
+
         output = Lyrics(lyric_list).to_LRC()
-        outfile = open(self.filepath, 'w')
+        outfile = codecs.open(self.filepath, 'w', 'utf-8')
         outfile.write(output)
         outfile.close()
 

--- a/operators/export_srt.py
+++ b/operators/export_srt.py
@@ -1,4 +1,5 @@
 import bpy
+import codecs
 from bpy_extras.io_utils import ExportHelper
 
 from .pysrt.srtitem import SubRipItem
@@ -10,46 +11,46 @@ class ExportSRT(bpy.types.Operator, ExportHelper):
     bl_label = 'Export SRT'
     bl_idname = 'sequencerextra.export_srt'
     bl_description = 'Export subtitles as SRT\n\nThis format is usually used for movies.'
-    
+
     filename_ext = ".srt"
-    
+
     @classmethod
     def poll(self, context):
         scene = context.scene
         try:
             text_strips = get_text_strips(scene)
-        
+
             if len(text_strips) > 0:
                 return True
             else:
                 return False
         except AttributeError:
             return False
-    
+
     def execute(self, context):
         scene = context.scene
         fps = scene.render.fps/scene.render.fps_base
         text_strips = get_text_strips(scene)
-        
+
         sub_lines = []
         for i in range(len(text_strips)):
             strip = text_strips[i]
-            
+
             start = (strip.frame_start / fps) * 1000
             end = (strip.frame_final_end / fps) * 1000
             text = strip.text
-            
+
             item = SubRipItem()
             item.text = text
             item.start.from_millis(start)
             item.end.from_millis(end)
             item.index = i + 1
             sub_lines.append(item)
-        
+
         output = SubRipFile(sub_lines).to_string()
-        
-        outfile = open(self.filepath, 'w')
+
+        outfile = codecs.open(self.filepath, 'w', 'utf-8')
         outfile.write(output)
         outfile.close()
-        
+
         return {"FINISHED"}


### PR DESCRIPTION
The SRT and LRC file exporting wasn't setting the file encoding to UTF-8. So when you use special characters in the subtitles and try to export then import the generated files, the special characters vanish from the strip.
Corrected setting the file encoding to UTF-8 when opening the file for write.