### PR TITLE
Fix #12

### DIFF
--- a/operators/tools/subtitles_to_sequencer.py
+++ b/operators/tools/subtitles_to_sequencer.py
@@ -19,7 +19,7 @@ def subtitles_to_sequencer(context, subs):
     added_strips = []
 
     for i in range(len(subs)):
-        start_time = int(subs[i].start.to_millis() / 1000)
+        start_time = subs[i].start.to_millis() / 1000
         strip_start = int(round(start_time * fps, 0))
 
         end_time = subs[i].end.to_millis() / 1000


### PR DESCRIPTION
The issue of overlapping clips is caused by converting the start times before rounding. This reverts the bug introduced in https://github.com/doakey3/Subsimport/commit/a56464b51cc45acb4c4c2d6085a2f463515e1430